### PR TITLE
Fix config file discovery on Windows

### DIFF
--- a/labml/internal/lab.py
+++ b/labml/internal/lab.py
@@ -194,7 +194,7 @@ class Lab:
                         config['config_file_path'] = path
                         configs.append(config)
 
-            if str(path) == path.root:
+            if str(path) == path.anchor:
                 break
 
             path = path.parent

--- a/labml/utils/__init__.py
+++ b/labml/utils/__init__.py
@@ -1,4 +1,4 @@
-import os
+import os, os.path
 from  pathlib import Path
 from typing import Set, List
 
@@ -14,7 +14,7 @@ def get_caller_file(ignore_callers: Set[str] = None) -> str:
 
     for f in frames:
         module_path = Path(f.filename)
-        if str(module_path).startswith(str(lab_src) + '/'):
+        if str(module_path).startswith(os.path.join(lab_src, '')):
             continue
         if str(module_path) in ignore_callers:
             continue

--- a/labml/utils/__init__.py
+++ b/labml/utils/__init__.py
@@ -18,11 +18,11 @@ def get_caller_file(ignore_callers: Set[str] = None) -> str:
             continue
         if str(module_path) in ignore_callers:
             continue
-        if not module_path.exists():
-            break
         if str(module_path).startswith('<stdin'):
             break
         if str(module_path).startswith('<ipython'):
+            break
+        if not module_path.exists():
             break
         if str(module_path.absolute()).find('/dist-packages/') != -1:
             continue


### PR DESCRIPTION
Presumably solves #60 (at least tested on my own Windows 10 environment).